### PR TITLE
Added reflink (CoW) and Windows support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,7 @@ getopts = "0.2.21"
 ctrlc = "3.2.5"
 blake3 = { version = "1.3.3", features = ["pure"] }
 smallvec = "1.10.0"
+libc = "0.2"
 
 [dependencies.serde]
 optional = true

--- a/src/bin.rs
+++ b/src/bin.rs
@@ -22,8 +22,8 @@ fn main() {
     opts.optflag("q", "quiet", "Hide regular progress output");
     opts.optmulti("e", "exclude", "Don't scan directories or files with that filename (wildcards are not supported)", "<exact filename>");
     opts.optflag("", "json", "Display results as JSON");
-    opts.optflag("r", "reflink", "Strict reflinking (copy-on-write) instead of hardlinking - WILL FAIL IF unsupported");
-    opts.optflag("f", "reflink-or-hardlink", "Try reflinks first, fallback to hardlinks if reflinks are not supported");
+    opts.optflag("C", "reflink", "Strict reflinking (copy-on-write) instead of hardlinking - WILL FAIL IF unsupported");
+    opts.optflag("c", "reflink-or-hardlink", "Try reflinks first, fallback to hardlinks if reflinks are not supported");
     opts.optflag("h", "help", "This help text");
 
     let mut args = env::args();

--- a/src/json.rs
+++ b/src/json.rs
@@ -29,6 +29,10 @@ impl ScanListener for JsonOutput {
         // output only at scan_over
     }
 
+    fn reflinked(&mut self, _: &Path, _: &Path) {
+        // output only at scan_over
+    }
+
     fn duplicate_found(&mut self, _: &Path, _: &Path) {
         // output only at scan_over
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,12 +4,14 @@ mod hasher;
 mod json;
 mod lazyfile;
 mod metadata;
+mod reflink;
 mod scanner;
 mod ui;
 
 pub use crate::file::FileContent;
 #[cfg(feature = "json")]
 pub use crate::json::JsonOutput;
+pub use crate::reflink::{LinkType, reflink, reflink_or_hardlink};
 pub use crate::scanner::RunMode;
 pub use crate::scanner::Scanner;
 pub use crate::ui::UI as TextUserInterface;

--- a/src/metadata.rs
+++ b/src/metadata.rs
@@ -1,6 +1,9 @@
 use std::fs;
 use std::io;
+#[cfg(unix)]
 use std::os::unix::fs::MetadataExt;
+#[cfg(windows)]
+use std::os::windows::fs::MetadataExt;
 use std::path::Path;
 
 #[derive(Copy, Clone, Hash, Ord, PartialOrd, PartialEq, Eq, Debug, Default)]
@@ -17,8 +20,22 @@ impl Metadata {
 
     pub fn new(m: &fs::Metadata) -> Self {
         Metadata {
-            dev: m.dev(),
-            size: m.size(),
+            dev: get_device_id(m),
+            size: m.len(),
         }
     }
+}
+
+#[cfg(unix)]
+fn get_device_id(m: &fs::Metadata) -> u64 {
+    m.dev()
+}
+
+#[cfg(windows)]
+fn get_device_id(m: &fs::Metadata) -> u64 {
+    // On Windows, it's possible to use the volume serial number as a device identifier
+    // For now, use a constant since Windows doesn't have a direct equivalent
+    // This means hardlinking across different drives won't work, but that's expected
+    use std::os::windows::fs::MetadataExt;
+    m.volume_serial_number().unwrap_or(0) as u64
 }

--- a/src/metadata.rs
+++ b/src/metadata.rs
@@ -19,7 +19,7 @@ impl Metadata {
     pub fn new(m: &fs::Metadata) -> Self {
         Metadata {
             dev: get_device_id(m),
-            size: m.len(),
+            size: get_size(m),
         }
     }
 }
@@ -36,4 +36,17 @@ fn get_device_id(_m: &fs::Metadata) -> u64 {
     // but that's expected behavior and matches filesystem limitations
     // TODO: In the future, we could use Windows-specific APIs to get proper device IDs
     0
+}
+
+#[cfg(unix)]
+fn get_size(m: &fs::Metadata) -> u64 {
+    m.size()
+}
+
+#[cfg(windows)]
+fn get_size(m: &fs::Metadata) -> u64 {
+    // Windows polyfill: round up to the next 4KB block to account for block overhead
+    let len = m.len();
+    const BLOCK_SIZE: u64 = 4096;
+    ((len + BLOCK_SIZE - 1) / BLOCK_SIZE) * BLOCK_SIZE
 }

--- a/src/metadata.rs
+++ b/src/metadata.rs
@@ -2,8 +2,6 @@ use std::fs;
 use std::io;
 #[cfg(unix)]
 use std::os::unix::fs::MetadataExt;
-#[cfg(windows)]
-use std::os::windows::fs::MetadataExt;
 use std::path::Path;
 
 #[derive(Copy, Clone, Hash, Ord, PartialOrd, PartialEq, Eq, Debug, Default)]
@@ -32,10 +30,10 @@ fn get_device_id(m: &fs::Metadata) -> u64 {
 }
 
 #[cfg(windows)]
-fn get_device_id(m: &fs::Metadata) -> u64 {
-    // On Windows, it's possible to use the volume serial number as a device identifier
-    // For now, use a constant since Windows doesn't have a direct equivalent
-    // This means hardlinking across different drives won't work, but that's expected
-    use std::os::windows::fs::MetadataExt;
-    m.volume_serial_number().unwrap_or(0) as u64
+fn get_device_id(_m: &fs::Metadata) -> u64 {
+    // On Windows, we'll use a simple constant for device identification
+    // This means hardlinking across different drives won't work properly,
+    // but that's expected behavior and matches filesystem limitations
+    // TODO: In the future, we could use Windows-specific APIs to get proper device IDs
+    0
 }

--- a/src/reflink.rs
+++ b/src/reflink.rs
@@ -108,7 +108,6 @@ fn reflink_macos(src: &Path, dst: &Path) -> io::Result<()> {
 
 #[cfg(target_os = "windows")]
 fn reflink_windows(src: &Path, dst: &Path) -> io::Result<()> {
-    use std::ffi::OsStr;
     use std::os::windows::ffi::OsStrExt;
     use std::ptr;
 

--- a/src/reflink.rs
+++ b/src/reflink.rs
@@ -1,0 +1,153 @@
+use std::fs;
+use std::io;
+use std::path::Path;
+
+#[derive(Debug, Copy, Clone, Eq, PartialEq)]
+pub enum LinkType {
+    Hardlink,
+    Reflink,
+}
+
+/// Create a reflink (copy-on-write link) between two files
+/// Falls back to hardlinking if reflinking is not supported
+pub fn reflink_or_hardlink(src: &Path, dst: &Path) -> io::Result<LinkType> {
+    // Try reflink first
+    match reflink(src, dst) {
+        Ok(()) => Ok(LinkType::Reflink),
+        Err(_) => {
+            // Fall back to hardlink
+            fs::hard_link(src, dst)?;
+            Ok(LinkType::Hardlink)
+        }
+    }
+}
+
+/// Create a reflink (copy-on-write link) between two files
+pub fn reflink(src: &Path, dst: &Path) -> io::Result<()> {
+    #[cfg(target_os = "linux")]
+    {
+        reflink_linux(src, dst)
+    }
+    #[cfg(target_os = "macos")]
+    {
+        reflink_macos(src, dst)
+    }
+    #[cfg(target_os = "windows")]
+    {
+        reflink_windows(src, dst)
+    }
+    #[cfg(not(any(target_os = "linux", target_os = "macos", target_os = "windows")))]
+    {
+        Err(io::Error::new(
+            io::ErrorKind::Unsupported,
+            "Reflinks are not supported on this platform",
+        ))
+    }
+}
+
+#[cfg(target_os = "linux")]
+fn reflink_linux(src: &Path, dst: &Path) -> io::Result<()> {
+    use std::ffi::CString;
+    use std::os::unix::ffi::OsStrExt;
+
+    let src_c = CString::new(src.as_os_str().as_bytes())?;
+    let dst_c = CString::new(dst.as_os_str().as_bytes())?;
+
+    unsafe {
+        // First try ioctl FICLONE (Btrfs, XFS)
+        let src_fd = libc::open(src_c.as_ptr(), libc::O_RDONLY);
+        if src_fd == -1 {
+            return Err(io::Error::last_os_error());
+        }
+
+        let dst_fd = libc::open(dst_c.as_ptr(), libc::O_WRONLY | libc::O_CREAT | libc::O_EXCL, 0o644);
+        if dst_fd == -1 {
+            libc::close(src_fd);
+            return Err(io::Error::last_os_error());
+        }
+
+        // FICLONE ioctl constant - this creates a reflink
+        const FICLONE: libc::c_ulong = 0x40049409;
+        let result = libc::ioctl(dst_fd, FICLONE, src_fd);
+        
+        libc::close(src_fd);
+        libc::close(dst_fd);
+
+        if result == 0 {
+            Ok(())
+        } else {
+            // Clean up the created file on failure
+            let _ = libc::unlink(dst_c.as_ptr());
+            Err(io::Error::last_os_error())
+        }
+    }
+}
+
+#[cfg(target_os = "macos")]
+fn reflink_macos(src: &Path, dst: &Path) -> io::Result<()> {
+    use std::ffi::CString;
+    use std::os::unix::ffi::OsStrExt;
+
+    let src_c = CString::new(src.as_os_str().as_bytes())?;
+    let dst_c = CString::new(dst.as_os_str().as_bytes())?;
+
+    unsafe {
+        // Use clonefile() on macOS
+        extern "C" {
+            fn clonefile(src: *const libc::c_char, dst: *const libc::c_char, flags: u32) -> libc::c_int;
+        }
+
+        let result = clonefile(src_c.as_ptr(), dst_c.as_ptr(), 0);
+        if result == 0 {
+            Ok(())
+        } else {
+            Err(io::Error::last_os_error())
+        }
+    }
+}
+
+#[cfg(target_os = "windows")]
+fn reflink_windows(src: &Path, dst: &Path) -> io::Result<()> {
+    use std::ffi::OsStr;
+    use std::os::windows::ffi::OsStrExt;
+    use std::ptr;
+
+    // Convert paths to wide strings for Windows API
+    let src_wide: Vec<u16> = src.as_os_str().encode_wide().chain(Some(0)).collect();
+    let dst_wide: Vec<u16> = dst.as_os_str().encode_wide().chain(Some(0)).collect();
+
+    unsafe {
+        // Windows doesn't have a direct equivalent to FICLONE, but it's possible to
+        // use the CopyFile API with COPY_FILE_COPY_SYMLINK | COPY_FILE_CLONE_FORCE.
+        // This requires Windows 10 version 1903 or later with a ReFS filesystem
+        
+        extern "system" {
+            fn CopyFileExW(
+                lpExistingFileName: *const u16,
+                lpNewFileName: *const u16,
+                lpProgressRoutine: *const u8,
+                lpData: *const u8,
+                pbCancel: *const i32,
+                dwCopyFlags: u32,
+            ) -> i32;
+        }
+
+        // COPY_FILE_CLONE_FORCE = 0x00800000 - Force a clone (reflink)
+        const COPY_FILE_CLONE_FORCE: u32 = 0x00800000;
+        
+        let result = CopyFileExW(
+            src_wide.as_ptr(),
+            dst_wide.as_ptr(),
+            ptr::null(),
+            ptr::null(),
+            ptr::null(),
+            COPY_FILE_CLONE_FORCE,
+        );
+
+        if result != 0 {
+            Ok(())
+        } else {
+            Err(io::Error::last_os_error())
+        }
+    }
+}

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -32,8 +32,8 @@ impl ScanListener for UI {
         let elapsed = self.timing.start_time.elapsed().as_secs();
         if elapsed > self.timing.next_update {
             self.timing.next_update = elapsed+1;
-            println!("{}+{} dupes ({} saved). {}+{} files scanned. {}/…",
-                stats.dupes, stats.hardlinks, human_size(stats.bytes_deduplicated), stats.added, stats.skipped,
+            println!("{}+{}+{} dupes ({} saved). {}+{} files scanned. {}/…",
+                stats.dupes, stats.hardlinks, stats.reflinks, human_size(stats.bytes_deduplicated), stats.added, stats.skipped,
                 path.parent().unwrap_or(path).display());
         }
     }
@@ -45,13 +45,17 @@ impl ScanListener for UI {
             x @ 5..=59 => format!("{}s", x),
             x => format!("{}m{}s", x / 60, x % 60),
         };
-        println!("Dupes found: {}, wasting {}. Existing hardlinks: {}, saving {}. Scanned: {}. Skipped {}. Total scan duration: {}",
+        println!("Dupes found: {}, wasting {}. Existing hardlinks: {}, saving {}. Reflinks created: {}, saving {}. Scanned: {}. Skipped {}. Total scan duration: {}",
             stats.dupes, human_size(stats.bytes_deduplicated), stats.hardlinks, human_size(stats.bytes_saved_by_hardlinks),
-            stats.added, stats.skipped, nice_duration);
+            stats.reflinks, human_size(stats.bytes_saved_by_reflinks), stats.added, stats.skipped, nice_duration);
     }
 
     fn hardlinked(&mut self, src: &Path, dst: &Path) {
         println!("Hardlinked {}", combined_paths(src, dst));
+    }
+
+    fn reflinked(&mut self, src: &Path, dst: &Path) {
+        println!("Reflinked {}", combined_paths(src, dst));
     }
 
     fn duplicate_found(&mut self, src: &Path, dst: &Path) {

--- a/tests/filetest.rs
+++ b/tests/filetest.rs
@@ -70,6 +70,7 @@ fn same_content() {
 }
 
 #[test]
+#[cfg(unix)] // Symlinks work differently on Windows
 fn symlink() {
     let dir = TempDir::new("sametest").unwrap();
     let a_path = dir.path().join("a").into_boxed_path();


### PR DESCRIPTION
Issue #19 mentioned wanting support for reflinking. I needed reflink support myself, so I decided to take a stab at it.

I have added the wiring to enable Windows support, but I do not have access to either a Mac or a Windows machine, so it remains untested. I have _only_ been able to test this on `btrfs` and it seems to work as intended. Given the limited testing on my end, **I thus invite people exercise caution and run some tests on a small batch of unimportant data before executing it YOLO in production.**

**FOR THE REPO OWNER**
Since it isn't useful to test on files which do not span across blocks, I tested it using the method below. Please let me know if anything needs fixing or if I've made any mistakes and I will rectify them.

```bash
# created a test file of 1MB
dd if=/dev/zero of=/path/to/dir-1/original.txt bs=1M count=1

# copied the original file from src/ to dest/ without reflinking it
cp --reflink=never /path/to/dir-1/original.txt /path/to/dir-2/copy.txt

# ran dupe-krill
dupe-krill --reflink-or-hardlink /path/to/dir-1/original.txt /path/to/dir-2/copy.txt

# checked if it is a reflink
filefrag -v /path/to/dir-1/original.txt /path/to/dir-2/copy.txt

# output
File size of /path/to/dir-1/original.txt is 1048576 (256 blocks of 4096 bytes)
 ext:     logical_offset:        physical_offset: length:   expected: flags:
   0:        0..     255:    2100057..   2100312:    256:             last,shared,eof
/path/to/dir-1/original.txt: 1 extent found

File size of /path/to/dir-2/copy.txt is 1048576 (256 blocks of 4096 bytes)
 ext:     logical_offset:        physical_offset: length:   expected: flags:
   0:        0..     255:    2100057..   2100312:    256:             last,shared,eof
/path/to/dir-2/copy.txt: 1 extent found

# made some changes to the file
echo "this is an edit" >> /path/to/dir-2/copy.txt

# ran the check again
filefrag -v /path/to/dir-1/original.txt /path/to/dir-2/copy.txt

# the edited file now had a shared offset and a distinct offset
Filesystem type is: 9123683e
File size of /path/to/dir-1/original.txt is 1048576 (256 blocks of 4096 bytes)
 ext:     logical_offset:        physical_offset: length:   expected: flags:
   0:        0..     255:    2100057..   2100312:    256:             last,shared,eof
/path/to/dir-1/original.txt: 1 extent found

File size of /path/to/dir-2/copy.txt is 1048592 (257 blocks of 4096 bytes)
 ext:     logical_offset:        physical_offset: length:   expected: flags:
   0:        0..     255:    2100057..   2100312:    256:             shared
   1:      256..     256:    3985770..   3985770:      1:    2100313: last,eof
/path/to/dir-2/copy.txt: 1 extent found
```

@patrickwolf Please do test this on your system to see if it works as intended. Brownie points if you test it on Mac and/or Windows 😄